### PR TITLE
Fix schema for IBM DB2 support

### DIFF
--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -13,7 +13,7 @@ create table account (
 );
 
 create table cashaccount (
-    id int,
+    id int not null,
     number varchar(80) not null,
     username varchar(80)  not null,
     availablebalance double precision,
@@ -22,7 +22,7 @@ create table cashaccount (
 );
 
 create table creditaccount(
-    id int,
+    id int not null,
     number varchar(80) not null,
     username varchar(80)  not null,
     description varchar(80)  not null,
@@ -33,7 +33,7 @@ create table creditaccount(
 
 
 create table transfer(
-    id serial,
+    id int generated always as identity not null,
     fromAccount varchar(80) not null,
     toAccount varchar(80)  not null,
     description varchar(80)  not null,
@@ -45,7 +45,7 @@ create table transfer(
 );
 
 create table transaction(
-    id serial,
+    id int generated always as identity not null,
     date TIMESTAMP,
     description varchar(80)  not null,
     number varchar(80) not null,


### PR DESCRIPTION
* IBM DB2 requires primary keys to be declared as not null.
* IBM DB2 does not support "serial" type. Changed to the standard SQL
  "identity" type that is supported by DB2 11.5, PostgreSQL 10, HSQLDB,
  etc.